### PR TITLE
Fix file extension bug

### DIFF
--- a/src/groovy/com/bertramlabs/plugins/selfie/Attachment.groovy
+++ b/src/groovy/com/bertramlabs/plugins/selfie/Attachment.groovy
@@ -192,7 +192,7 @@ class Attachment {
 		def extension 
 		try {
 			extension = (fileName =~ /[.]([^.]+)$/)[0][1]
-			"${fileNameWithOutExt}_${typeName}.${extension?.toLowerCase()}"
+			"${fileNameWithOutExt}_${typeName}.${extension?.toLowerCase()}" //uppercase extensions prevent correct content type detection
 		} catch (IndexOutOfBoundsException e) {
 			//file has no extension
 			"${fileNameWithOutExt}_${typeName}"

--- a/src/groovy/com/bertramlabs/plugins/selfie/Attachment.groovy
+++ b/src/groovy/com/bertramlabs/plugins/selfie/Attachment.groovy
@@ -190,7 +190,7 @@ class Attachment {
 	String fileNameForType(typeName) {
 		def fileNameWithOutExt = fileName.replaceFirst(/[.][^.]+$/, "")
 		def extension = (fileName =~ /[.]([^.]+)$/)[0][1]
-		"${fileNameWithOutExt}_${typeName}.${extension}"
+		"${fileNameWithOutExt}_${typeName}.${extension?.toLowerCase()}"
 	}
 
 	def getStyles() {

--- a/src/groovy/com/bertramlabs/plugins/selfie/Attachment.groovy
+++ b/src/groovy/com/bertramlabs/plugins/selfie/Attachment.groovy
@@ -189,8 +189,14 @@ class Attachment {
 
 	String fileNameForType(typeName) {
 		def fileNameWithOutExt = fileName.replaceFirst(/[.][^.]+$/, "")
-		def extension = (fileName =~ /[.]([^.]+)$/)[0][1]
-		"${fileNameWithOutExt}_${typeName}.${extension?.toLowerCase()}"
+		def extension 
+		try {
+			extension = (fileName =~ /[.]([^.]+)$/)[0][1]
+			"${fileNameWithOutExt}_${typeName}.${extension}"
+		} catch (IndexOutOfBoundsException e) {
+			//file has no extension
+			"${fileNameWithOutExt}_${typeName}"
+		}
 	}
 
 	def getStyles() {

--- a/src/groovy/com/bertramlabs/plugins/selfie/Attachment.groovy
+++ b/src/groovy/com/bertramlabs/plugins/selfie/Attachment.groovy
@@ -192,7 +192,7 @@ class Attachment {
 		def extension 
 		try {
 			extension = (fileName =~ /[.]([^.]+)$/)[0][1]
-			"${fileNameWithOutExt}_${typeName}.${extension}"
+			"${fileNameWithOutExt}_${typeName}.${extension?.toLowerCase()}"
 		} catch (IndexOutOfBoundsException e) {
 			//file has no extension
 			"${fileNameWithOutExt}_${typeName}"


### PR DESCRIPTION
I found a solution for the content type bug I reported: https://github.com/bertramdev/selfie/issues/9

The way selfie determines content types apparently does not work with uppercase extensions, so I added conversion to lowercase in the fileNameForType method. This does not affect the actual filename which is stored in the file system, only its representation in code.
In addition, I caught an exception for files without extensions so they can be used with selfie.

However, I don't know your code well enough to rule out side effects this modification to the return value of fileNameForType might have.