### PR TITLE
Added `fill` option to ImageResizer 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
     id "com.jfrog.bintray" version "1.6"
 }
 
-version "1.2.1"
+version "1.2.2-SNAPSHOT"
 group "com.bertramlabs.plugins"
 
 apply plugin:"eclipse"
@@ -52,7 +52,7 @@ dependencies {
     compile "org.grails:grails-web-boot"
     compile "org.grails.plugins:cache"
     compile 'org.imgscalr:imgscalr-lib:4.2'
-    compile 'com.bertramlabs.plugins:karman-grails:0.11.2'
+    compile 'com.bertramlabs.plugins:karman-grails:1.1.1'
 
     console "org.grails:grails-console"
 

--- a/src/main/groovy/com/bertramlabs/plugins/selfie/processors/ImageResizer.groovy
+++ b/src/main/groovy/com/bertramlabs/plugins/selfie/processors/ImageResizer.groovy
@@ -39,9 +39,9 @@ class ImageResizer {
 			def typeFileName = attachment.fileNameForType(typeName)
 			def outputImage
 
-			if(options.mode == 'fit' || options.mode == 'fity' || options.mode == 'fitx' ) {
+			if(options.mode == 'fit' || options.mode == 'fity' || options.mode == 'fitx' || options.mode == 'fill') {
 				def mode = Scalr.Mode.FIT_TO_HEIGHT
-				if(options.mode == 'fit') {
+				if(options.mode == 'fit' || options.mode == 'fill') {
 					if(image.width > options.width || image.height > options.height) {
 						if(image.width - options.width >= image.height - options.height) {
 							mode = Scalr.Mode.FIT_TO_WIDTH
@@ -59,8 +59,12 @@ class ImageResizer {
 							mode = Scalr.Mode.FIT_TO_WIDTH
 						}
 					}
-					
-				} else if(options.mode == 'fitx') {
+					if(options.mode == 'fill'){
+						mode = (mode == Scalr.Mode.FIT_TO_HEIGHT)?
+							Scalr.Mode.FIT_TO_WIDTH:Scalr.Mode.FIT_TO_HEIGHT
+					}
+				}
+				else if(options.mode == 'fitx') {
 					mode = Scalr.Mode.FIT_TO_WIDTH
 				} else {
 					mode = Scalr.Mode.FIT_TO_HEIGHT


### PR DESCRIPTION
Updated karman dependency, and added a `fill` option to the imageResizer mode. Let's say you have an image 1920x1080 or 1080x1920 and want a result image of 200x200, `fill` ensures to do so. It will resize and crop to smallest size of the image. 